### PR TITLE
Version 2 - CI/CD, switch to Ubuntu, add License, version bump

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @hajowieland

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,6 @@
+documentation:
+  - ./*.md
+
+ci:
+  - .dependabot/*
+  - .github/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+name: Pull Request Labeler
+
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+name: Lint Dockerfile
+
+on:
+  pull_request:
+
+jobs:
+  linter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@master
+        with:
+          dockerfile: "Dockerfile"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,64 @@
+name: Build / Publish Docker image
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - '*'
+  pull_request:
+
+jobs:
+  push-to-registry:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          flavor: latest=true
+          images: ventx/debug-pod
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+            REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+            VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+
+      - name: Sync Docker Hub README
+        if: github.event_name != 'pull_request'
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ventx/debug-pod
+
+      - name: Sync Docker Hub Description
+        if: github.event_name != 'pull_request'
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ventx/debug-pod
+          short-description: ${{ github.event.repository.description }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Create Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-please:
+    name: release-please
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          extra-files: |
+            README.md
+          include-v-in-tag: false
+          release-type: simple
+          token: ${{ secrets.PAT_RELEASE_PLEASE }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.12.0
+    hooks:
+      - id: hadolint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,57 @@
-FROM alpine:3.13
+FROM ubuntu:22.04
 
-LABEL maintainer="hajo@ventx.de" \
-      org.opencontainers.image.title="ventx/helm3-ci" \
+ARG BUILDTIME
+ARG REVISION
+ARG TARGETPLATFORM
+ARG VERSION
+
+LABEL maintainer="Hans Jörg Wieland <hajo@ventx.de>" \
+      org.opencontainers.image.authors="Hans Jörg Wieland <hajo@ventx.de>" \
+      org.opencontainers.image.base.name="ubuntu:22.04" \
+      org.opencontainers.image.created="${BUILDTIME}" \
       org.opencontainers.image.description="Helm Charts Pipeline runner container image" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.ref.name="ventx/helm3-ci" \
+      org.opencontainers.image.revision="${REVISION}" \
       org.opencontainers.image.source="https://github.com/ventx/helm3-ci" \
-      org.opencontainers.image.vendor="ventx"
+      org.opencontainers.image.url="https://github.com/ventx/helm3-ci.git" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.vendor="ventx GmbH"
 
 # Tool versions
-ENV CT 3.3.1
-ENV HELM 3.5.4
-ENV HELM_SECRETS 3.6.1
-ENV HELM_UNITTEST 0.2.6
-ENV KUBECTL 1.19.6
-ENV KUBESCORE 1.11.0
-ENV KUBESEC 2.11.0
-ENV KUBEVAL 0.16.1
-ENV YAMALE 3.0.4
-ENV YAMLLINT 1.26.1
+ENV CT 3.8.0
+ENV DEBIAN_FRONTEND="noninteractive"
+ENV HELM="3.12.1"
+ENV HELM_SECRETS="4.4.2"
+ENV HELM_UNITTEST="0.3.3"
+ENV KUBECTL="1.25.11"
+ENV KUBESCORE="1.16.1"
+ENV KUBESEC="2.13.0"
+ENV KUBECONFORM="0.6.2"
+ENV TZ="Europe/Berlin"
+ENV YAMALE="4.0.4"
+ENV YAMLLINT="1.32.0"
 
-# apk package versions
-ENV BASH 5.1.0-r0
-ENV CURL 7.76.1-r0
-ENV GIT 2.30.2-r0
-ENV MAKE 4.3-r0
-ENV OPENSSH_CLIENT 8.4_p1-r3
-ENV PYTHON3 3.8.8-r0
-ENV PY3_PIP 20.3.4-r0
+# Instal packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  tzdata=2023c-0ubuntu0.22.04.2 \
+  ca-certificates=20230311ubuntu0.22.04.1 \
+  curl=7.81.0-1ubuntu1.10 \
+  git=1:2.34.1-1ubuntu1.9 \
+  gnupg=2.2.27-3ubuntu2.1 \
+  jq=1.6-2.1ubuntu3 \
+  make=4.3-4.1build1 \
+  openssh-client=1:8.9p1-3ubuntu0.1 \
+  python3-pip=22.0.2+dfsg-1ubuntu0.3 \
+  wget=1.21.2-2ubuntu1 \
+  && rm -rf /var/lib/apt/lists/*
 
-RUN apk --update --no-cache add \
-  bash="${BASH}" \
-  curl="${CURL}" \
-  git="${GIT}" \
-  make="${MAKE}" \
-  openssh-client="${OPENSSH_CLIENT}" \
-  python3="${PYTHON3}" \
-  py3-pip="${PY3_PIP}" \
-  && rm -rf /var/cache/apk/*
+# Config ca-certificates for wget
+RUN echo "ca_certificate=/etc/ssl/certs/ca-certificates.crt" > "$HOME/.wgetrc"
+
+# Set Timezone
+RUN ln -fs "/usr/share/zoneinfo/$TZ" /etc/localtime && \
+  dpkg-reconfigure --frontend noninteractive tzdata
 
 # pip packages
 RUN pip3 install --no-cache-dir \
@@ -43,32 +59,38 @@ RUN pip3 install --no-cache-dir \
     yamllint=="${YAMLLINT}"
 
 # Helm3
-RUN curl -Ls "https://get.helm.sh/helm-v${HELM}-linux-amd64.tar.gz" | tar -xzO linux-amd64/helm > /usr/local/bin/helm && \
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; else echo "Unsupported Architeture" && exit 1; fi && \
+    curl -SsL "https://get.helm.sh/helm-v${HELM}-linux-${ARCHITECTURE}.tar.gz" | tar -xzO linux-${ARCHITECTURE}/helm > /usr/local/bin/helm && \
     chmod +x /usr/local/bin/helm
 
 #  Helm plugins
 RUN helm plugin install https://github.com/jkroepke/helm-secrets --version "v${HELM_SECRETS}"
-RUN helm plugin install https://github.com/quintush/helm-unittest --version "v${HELM_UNITTEST}"
+RUN helm plugin install https://github.com/helm-unittest/helm-unittest --version "v${HELM_UNITTEST}"
 
 # chart-testing
-RUN curl -Ls https://github.com/helm/chart-testing/releases/download/v${CT}/chart-testing_${CT}_linux_amd64.tar.gz | tar -xzO ct > /usr/local/bin/ct && \
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; else echo "Unsupported Architeture" && exit 1; fi && \
+    curl -sLS https://github.com/helm/chart-testing/releases/download/v${CT}/chart-testing_${CT}_linux_${ARCHITECTURE}.tar.gz | tar -xzO ct > /usr/local/bin/ct && \
     chmod +x /usr/local/bin/ct
 
 # kubectl
-RUN curl -Ls "https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL}/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && \
-    chmod +x /usr/local/bin/kubectl
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=linux/amd64; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=linux/arm64; else echo "Unsupported Architeture" && exit 1; fi && \
+  curl -sLS -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL}/bin/${ARCHITECTURE}/kubectl && \
+  chmod +x /usr/local/bin/kubectl
 
 # kube-score
-RUN curl -Ls "https://github.com/zegl/kube-score/releases/download/v${KUBESCORE}/kube-score_${KUBESCORE}_linux_amd64" > /usr/local/bin/kube-score && \
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; else echo "Unsupported Architeture" && exit 1; fi && \
+    curl -sLS "https://github.com/zegl/kube-score/releases/download/v${KUBESCORE}/kube-score_${KUBESCORE}_linux_${ARCHITECTURE}" > /usr/local/bin/kube-score && \
     chmod +x /usr/local/bin/kube-score
 
 # kubesec
-RUN curl -Ls "https://github.com/controlplaneio/kubesec/releases/download/v${KUBESEC}/kubesec_linux_amd64.tar.gz" | tar -xzO kubesec > /usr/local/bin/kubesec && \
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; else echo "Unsupported Architeture" && exit 1; fi && \
+    curl -sLS "https://github.com/controlplaneio/kubesec/releases/download/v${KUBESEC}/kubesec_linux_${ARCHITECTURE}.tar.gz" | tar -xzO kubesec > /usr/local/bin/kubesec && \
     chmod +x /usr/local/bin/kubesec
 
-# kubeval
-RUN curl -Ls "https://github.com/instrumenta/kubeval/releases/download/v${KUBEVAL}/kubeval-linux-amd64.tar.gz" | tar -xzO kubeval > /usr/local/bin/kubeval && \
-    chmod +x /usr/local/bin/kubeval
+# kubeconform
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; else echo "Unsupported Architeture" && exit 1; fi && \
+    curl -sLS https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM}/kubeconform-linux-${ARCHITECTURE}.tar.gz | tar -xzO kubeconform > /usr/local/bin/kubeconform && \
+    chmod +x /usr/local/bin/kubeconform
 
 WORKDIR /work
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 ventx GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,44 +1,52 @@
 # helm3-ci
 
-Small Alpine Docker image with tools and plugins for Helm charts in **C**ontinous **I**ntegration pipelines.
+[![Docker Pulls](https://img.shields.io/docker/pulls/ventx/helm3-ci.svg)](https://hub.docker.com/r/ventx/debug-pod/)
 
+Multi-Arch image with tools and plugins for Helm Charts in **C**ontinous **I**ntegration pipelines.
 
 ## Docker Hub
 
-[ventx/helm3-ci](https://cloud.docker.com/u/ventx/repository/docker/ventx/helm3-ci)
+[ventx/helm3-ci:0.7.0](https://hub.docker.com/r/ventx/helm3-ci) <!-- {x-release-please-version} -->
 
 
-# Docker base image
+## Docker image
 
-* OS: [Alpine Linux](https://alpinelinux.org/)
-* Version: 3.13
+* OS: Ubuntu
+* Version: 22.04 LTS ("Jammy")
 
+## Architectures
 
-# Installed Packages
+* linux/amd64
+* linux/arm64
 
-* [bash](https://pkgs.alpinelinux.org/packages?name=bash&branch=v3.13)
-* [curl](https://pkgs.alpinelinux.org/packages?name=curl&branch=v3.13)
-* [git](https://pkgs.alpinelinux.org/packages?name=git&branch=v3.13)
-* [make](https://pkgs.alpinelinux.org/packages?name=make&branch=v3.13)
-* [openssh-client](https://pkgs.alpinelinux.org/packages?name=openssh-client&branch=v3.13)
-* [python3](https://pkgs.alpinelinux.org/packages?name=python3&branch=v3.13)
-* [py3-pip](https://pkgs.alpinelinux.org/packages?name=py3-pip&branch=v3.13)
+## Installed Packages (apt)
+
+* [ca-certificates](https://packages.ubuntu.com/jammy/ca-certificates)
+* [curl](https://packages.ubuntu.com/jammy/curl)
+* [git](https://packages.ubuntu.com/jammy/git)
+* [gnupg](https://packages.ubuntu.com/jammy/gnupg)
+* [jq](https://packages.ubuntu.com/jammy/jq)
+* [make](https://packages.ubuntu.com/jammy/make)
+* [openssh-client](https://packages.ubuntu.com/jammy/openssh-client)
+* [python3-pip](https://packages.ubuntu.com/jammy/python3-pip)
+* [tzdata](https://packages.ubuntu.com/jammy/tzdata)
+* [wget](https://packages.ubuntu.com/jammy/wget)
 
 
 # Installed Packages (go binaries)
 
-* [chart-testing](https://github.com/helm/chart-testing) `v3.3.1`
-* [helm](https://helm.sh/) `v3.5.4`
-* [kubeval](https://www.kubeval.com) `v0.16.1`
-* [kubectl](https://github.com/kubernetes/kubectl) `v1.19.6`
+* [chart-testing](https://github.com/helm/chart-testing)
+* [helm](https://helm.sh/)
+* [kubeval](https://www.kubeval.com)
+* [kubectl](https://github.com/kubernetes/kubectl)
 
 # Installed Packages (Python3 - pip)
 
-* [yamale](https://pypi.org/project/yamale/) `3.0.4`
-* [yamllint](https://pypi.org/project/yamllint/) `1.26.1`
+* [yamale](https://pypi.org/project/yamale/)
+* [yamllint](https://pypi.org/project/yamllint/)
 
 
 # Helm Plugins
 
-* [helm-secrets](https://github.com/jkroepke/helm-secrets) `v3.6.1`
-* [helm-unittest](https://github.com/quintush/helm-unittest) `v0.2.6`
+* [helm-secrets](https://github.com/jkroepke/helm-secrets)
+* [helm-unittest](https://github.com/helm-unittest/helm-unittest)


### PR DESCRIPTION
Version 2.0

- Replace legacy kubeval with kubeconform
- Version bump of all tools
- add MIT License
- Switch to Ubuntu as base image (glibc)
- add pre-commit hook for linting with hadolint
- CI/CD GitHub actions and release-please on conventional-commits