### PR TITLE
Local Kubernetes Schema JSON files for air-gapped environments

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,3 +14,4 @@ jobs:
         uses: hadolint/hadolint-action@master
         with:
           dockerfile: "Dockerfile"
+          ignore: "DL3003"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,4 +4,5 @@ repos:
     hooks:
       - id: hadolint
         args:
-          - "--ignore DL3003"
+          - --ignore
+          - DL3003

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,5 @@ repos:
     rev: v2.12.0
     hooks:
       - id: hadolint
+        args:
+          - --ignore DL3003

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,4 +4,4 @@ repos:
     hooks:
       - id: hadolint
         args:
-          - --ignore DL3003
+          - "--ignore DL3003"

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,11 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; elif [ "$
     curl -sLS "https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM}/kubeconform-linux-${ARCHITECTURE}.tar.gz" | tar -xzO kubeconform > /usr/local/bin/kubeconform && \
     chmod +x /usr/local/bin/kubeconform
 
+# kubernetes-json-schema
+RUN git clone --depth 1 --branch master --no-checkout https://github.com/yannh/kubernetes-json-schema.git && \
+    cd kubernetes-json-schema && git sparse-checkout set v${KUBECTL}-standalone-strict && git checkout master && \
+    mkdir -p /schema && cp -r v${KUBECTL}-standalone-strict /schema/ && cd .. && rm -rf kubernetes-json-schema
+    
 WORKDIR /work
 
 CMD ["helm", "version"]


### PR DESCRIPTION
Added the JSON Schema files from https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master into the local filesystem path `/schema`. This is useful for air-gapped environments where no internet connection is available.

The version of the schema files depends on the `KUBECTL` environment variable.

