### PR TITLE
add chart-testing default config and updated apt packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,8 +75,9 @@ RUN helm plugin install https://github.com/jkroepke/helm-secrets --version "v${H
 
 # chart-testing
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; else echo "Unsupported Architeture" && exit 1; fi && \
-    curl -sLS "https://github.com/helm/chart-testing/releases/download/v${CT}/chart-testing_${CT}_linux_${ARCHITECTURE}.tar.gz" > ct.tar.gz && \
-    tar -xzf ct.tar.gz && mv ct /usr/local/bin/ct && chmod a+x /usr/local/bin/ct && mkdir /etc/ct && cp etc/* /etc/ct
+    curl -sLS "https://github.com/helm/chart-testing/releases/download/v${CT}/chart-testing_${CT}_linux_${ARCHITECTURE}.tar.gz" > /tmp/ct.tar.gz && \
+    tar -xzf /tmp/ct.tar.gz -C /tmp/ && mv /tmp/ct /usr/local/bin/ct && chmod a+x /usr/local/bin/ct && mkdir /etc/ct && cp /tmp/etc/* /etc/ct/ && \
+    rm -rf /tmp/*
 
 # kubectl
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=linux/amd64; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=linux/arm64; else echo "Unsupported Architeture" && exit 1; fi && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN pip3 install --no-cache-dir \
 
 # Helm3
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; else echo "Unsupported Architeture" && exit 1; fi && \
-    curl -SsL "https://get.helm.sh/helm-v${HELM}-linux-${ARCHITECTURE}.tar.gz" | tar -xzO "linux-${ARCHITECTURE}/helm" > /usr/local/bin/helm && \
+    curl -sLS "https://get.helm.sh/helm-v${HELM}-linux-${ARCHITECTURE}.tar.gz" | tar -xzO "linux-${ARCHITECTURE}/helm" > /usr/local/bin/helm && \
     chmod +x /usr/local/bin/helm
 
 #  Helm plugins
@@ -110,7 +110,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; elif [ "$
 
 # yq
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; else ARCHITECTURE=amd64; fi && \
-  curl -SsL -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ}/yq_linux_${ARCHITECTURE} && \
+  curl -sLS -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ}/yq_linux_${ARCHITECTURE} && \
   chmod +x /usr/local/bin/yq
 
 WORKDIR /work

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,15 +40,15 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Instal packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  tzdata=2023c-0ubuntu0.22.04.2 \
+  tzdata=2023d-0ubuntu0.22.04 \
   ca-certificates=20230311ubuntu0.22.04.1 \
-  curl=7.81.0-1ubuntu1.13 \
+  curl=7.81.0-1ubuntu1.15 \
   git=1:2.34.1-1ubuntu1.10 \
   gnupg=2.2.27-3ubuntu2.1 \
   jq=1.6-2.1ubuntu3 \
   make=4.3-4.1build1 \
-  openssh-client=1:8.9p1-3ubuntu0.3 \
-  python3-pip=22.0.2+dfsg-1ubuntu0.3 \
+  openssh-client=1:8.9p1-3ubuntu0.6 \
+  python3-pip=22.0.2+dfsg-1ubuntu0.4 \
   wget=1.21.2-2ubuntu1 \
   && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,8 +75,8 @@ RUN helm plugin install https://github.com/jkroepke/helm-secrets --version "v${H
 
 # chart-testing
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; else echo "Unsupported Architeture" && exit 1; fi && \
-    curl -sLS "https://github.com/helm/chart-testing/releases/download/v${CT}/chart-testing_${CT}_linux_${ARCHITECTURE}.tar.gz" | tar -xzO ct > /usr/local/bin/ct && \
-    chmod +x /usr/local/bin/ct
+    curl -sLS "https://github.com/helm/chart-testing/releases/download/v${CT}/chart-testing_${CT}_linux_${ARCHITECTURE}.tar.gz" > ct.tar.gz && \
+    tar -xzf ct.tar.gz && mv ct /usr/local/bin/ct && chmod a+x /usr/local/bin/ct && mkdir /etc/ct && cp etc/* /etc/ct
 
 # kubectl
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=linux/amd64; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=linux/arm64; else echo "Unsupported Architeture" && exit 1; fi && \


### PR DESCRIPTION
Fixes #16  

- Added the chart-testing default configs (`chart_schema.yaml`, `lintconf.yaml`) so no configs need to be provided
- Updated apt packages to latest available versions


```bash
# ls -lah /etc/ct
total 16K
drwxr-xr-x 2 root root 4.0K Jan 29 10:22 .
drwxr-xr-x 1 root root 4.0K Jan 29 10:23 ..
-rw-r--r-- 1 root root 1017 Jan 29 10:22 chart_schema.yaml
-rw-r--r-- 1 root root 1.1K Jan 29 10:22 lintconf.yaml
```